### PR TITLE
Silta container base image migration to Docker Hub

### DIFF
--- a/docs/gcp_filestore_migration.md
+++ b/docs/gcp_filestore_migration.md
@@ -70,7 +70,7 @@ If you run out of free space on volume, contact cluster administrator for its ex
     ```
     Dockerfile example of a project
     ```dockerfile
-    FROM eu.gcr.io/silta-images/php:8.0-fpm-v0.1
+    FROM wunderio/silta-php-fpm:8.0-fpm-v0.1
     
     COPY --chown=www-data:www-data . /app
     

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -26,7 +26,7 @@ Versions available are listed here: https://github.com/wunderio/silta-images/tre
 
 Note: nginx:v0.1, wunderio/drupal Docker images do not have this module.
 
-Example: `FROM eu.gcr.io/silta-images/nginx:latest`
+Example: `FROM wunderio/silta-nginx:latest`
 
 # Issues with the deployed environments
 
@@ -52,7 +52,7 @@ Possible causes:
 
 - The `shell` pod is not done deploying. Wait for ten seconds and try again.
 
-- There is no `shell` access in frontend chart by default, You need to enable it (`shell.enabled: true`) and use customized base images from https://eu.gcr.io/silta-images/node 
+- There is no `shell` access in frontend chart by default, You need to enable it (`shell.enabled: true`) and use customized base images from https://wunderio/silta-node 
 
 ## Q: Timeout without error when connecting via SSH
 
@@ -285,7 +285,7 @@ Content of [silta/shell.Dockerfile](https://github.com/wunderio/drupal-project/b
 
 ```
 # Dockerfile for the Shell container.
-FROM eu.gcr.io/silta-images/shell:php7.4-v0.1
+FROM wunderio/silta-php-shell:php7.4-v0.1
 
 COPY --chown=www-data:www-data . /app
 ```
@@ -309,7 +309,7 @@ If You want to test docker images locally, You'd need to install docker or other
 
 Running a docker image:
 ```bash
-docker run -it --entrypoint sh eu.gcr.io/silta-images/shell:php7.4-v0.1
+docker run -it --entrypoint sh wunderio/silta-php-shell:php7.4-v0.1
 ```
 
 This will download shell image and run a shell inside it. Typing `exit` will quit and stop the container.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -52,7 +52,7 @@ Possible causes:
 
 - The `shell` pod is not done deploying. Wait for ten seconds and try again.
 
-- There is no `shell` access in frontend chart by default, You need to enable it (`shell.enabled: true`) and use customized base images from https://wunderio/silta-node 
+- There is no `shell` access in frontend chart by default, You need to enable it (`shell.enabled: true`) and use customized base images from https://hub.docker.com/r/wunderio/silta-node 
 
 ## Q: Timeout without error when connecting via SSH
 


### PR DESCRIPTION
Silta docker container images are being migrated from [Google Container Registry](https://eu.gcr.io/silta-images/) to [Docker Hub](https://hub.docker.com/u/wunderio).
This PR changes base image location to the new image registry and adjusts some image names.

Please review adjusted image paths and make sure this PR only changes relevant configuration files.

This pull request was created with https://github.com/wunderio/internal-mass-updater.