### PR TITLE
Improve shell commands

### DIFF
--- a/docs/gcp_filestore_migration.md
+++ b/docs/gcp_filestore_migration.md
@@ -40,8 +40,8 @@ If you run out of free space on volume, contact cluster administrator for its ex
     dir=/app/web/sites/default/files-new
     chown -R www-data:www-data "$dir"
     chmod 770 "$dir"
-    find "$dir" -type d -print0 | xargs -0 chmod 770
-    find "$dir" -type f -print0 | xargs -0 chmod 660
+    find "$dir" -type d -print0 | xargs -0 --max-args=100 chmod 770
+    find "$dir" -type f -print0 | xargs -0 --max-args=100 chmod 660
     ```
 
 6. Update the mount path for the new mount, disable the old one

--- a/docs/gcp_filestore_migration.md
+++ b/docs/gcp_filestore_migration.md
@@ -37,10 +37,11 @@ If you run out of free space on volume, contact cluster administrator for its ex
 
 5. Set ownership and permissions for the new location
     ```bash
-    chown -R www-data:www-data /app/web/sites/default/files-new
-    chmod 770 /app/web/sites/default/files-new
-    find /app/web/sites/default/files-new -type d -exec chmod 770 '{}' \;
-    find /app/web/sites/default/files-new -type f -exec chmod 660 '{}' \;
+    dir=/app/web/sites/default/files-new
+    chown -R www-data:www-data "$dir"
+    chmod 770 "$dir"
+    find "$dir" -type d -print0 | xargs -0 chmod 770
+    find "$dir" -type f -print0 | xargs -0 chmod 660
     ```
 
 6. Update the mount path for the new mount, disable the old one


### PR DESCRIPTION
The proposed `find` commands were slow/inefficient due to the fact they execute `chmod` for each filesystem object.
A better solution is to execute `chmod` once having a list of files as arguments.
The files are null-terminated. That handles safely files with special characters.