### PR TITLE
Documented a faster way of syncing files while migrating to Filestore.

### DIFF
--- a/docs/gcp_filestore_migration.md
+++ b/docs/gcp_filestore_migration.md
@@ -33,16 +33,23 @@ If you run out of free space on volume, contact cluster administrator for its ex
     ```
 
 4. Copy public files from the old location to the new one
-    ```bash
-    cd /app/web/sites/default/files
-    find . -maxdepth 2 -mindepth 2 -type d | xargs -P15 -I% rsync --relative --info=progress2 -az % /app/web/sites/default/files-new/ \
-      && find . -maxdepth 2 -mindepth 2 -type f  | xargs -P15 -I% rsync --relative --info=progress2 -az % /app/web/sites/default/files-new/ \
-      && find . -maxdepth 1 -mindepth 1 -type f  | xargs -P15 -I% rsync --relative --info=progress2 -az % /app/web/sites/default/files-new/
+
+     4.1. Simple way, for small amounts of files:
+      ```bash
+      rsync --info=progress2 -az /app/web/sites/default/files/ /app/web/sites/default/files-new/
+      ```
    
-    # Verify file count matches in both directories
-    find /app/web/sites/default/files/ | wc -l \
-      && find /app/web/sites/default/files-new/ | wc -l
-    ```
+     4.2. Advanced way, for large amounts of files:
+      ```bash
+      cd /app/web/sites/default/files
+      find . -maxdepth 2 -mindepth 2 -type d | xargs -P15 -I% rsync --relative --info=progress2 -az % /app/web/sites/default/files-new/ \
+        && find . -maxdepth 2 -mindepth 2 -type f  | xargs -P15 -I% rsync --relative --info=progress2 -az % /app/web/sites/default/files-new/ \
+        && find . -maxdepth 1 -mindepth 1 -type f  | xargs -P15 -I% rsync --relative --info=progress2 -az % /app/web/sites/default/files-new/
+      
+      # Verify file count matches in both directories
+      find /app/web/sites/default/files/ | wc -l \
+        && find /app/web/sites/default/files-new/ | wc -l
+      ```
 
 5. Set ownership and permissions for the new location
     ```bash


### PR DESCRIPTION
Makes the file sync almost 4 times faster, at least when I tested with 540M set of files.

Explanation of the new commands:

- First, `cd` into the old `files` directory, in order to keep the directory tree structure intact when using rsyncs `--relative`  flag.
- Use `find` to list directories and files, pipe them to `xargs`, which runs 15 parallel processes of `rsync` (multithreading)
- The 1st command syncs second level subdirectories eg `files/foo/bar/`
- The 2nd command syncs second level files eg `files/foo/bar.jpg`, including the first level directories eg `files/foo/`
- The 3rd command syncs first level files eg `files/bar.jpg`
- I split the sync into these three commands because it was much faster than using a single one

As an example, if there's around 10G of files, this method should decrease sync time from approx 104min to 27min.