### PR TITLE
Add possible cause of refused connection via SSH

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -54,7 +54,7 @@ Possible causes:
 
 - There is no `shell` access in frontend chart by default, You need to enable it (`shell.enabled: true`) and use customized base images from https://hub.docker.com/r/wunderio/silta-node 
 
-- The environment has been downscaled to standby and has not been yet re-launched
+- The environment has been downscaled to standby and has not been yet re-launched. Visit the environment URL and press the button to trigger upscaling.
 
 ## Q: Timeout without error when connecting via SSH
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -54,6 +54,8 @@ Possible causes:
 
 - There is no `shell` access in frontend chart by default, You need to enable it (`shell.enabled: true`) and use customized base images from https://hub.docker.com/r/wunderio/silta-node 
 
+- The environment has been downscaled to standby and has not been yet re-launched
+
 ## Q: Timeout without error when connecting via SSH
 
 Error:


### PR DESCRIPTION
When trying to access environment that has been downsacled, you'll get an error:

```bash
channel 0: open failed: connect failed: Connection refused
stdio forwarding failed
kex_exchange_identification: Connection closed by remote host
Connection closed by UNKNOWN port 65535
```