### PR TITLE
Silta v1.0 components

### DIFF
--- a/docs/anatomy_of_a_silta_project.md
+++ b/docs/anatomy_of_a_silta_project.md
@@ -16,7 +16,7 @@ This file is located in the project root at `.circleci/config.yml` and uses the 
 version: 2.1
 
 orbs:
-  silta: silta/silta@0.1
+  silta: silta/silta@1
 
 workflows:
   version: 2
@@ -58,7 +58,7 @@ We use version 2.1 of the CircleCI API. If your project configured to use an old
 
 ```yaml
 orbs:
-  silta: silta/silta@0.1
+  silta: silta/silta@1
 ```
 CircleCI has a packaging system called [orbs](https://circleci.com/docs/2.0/orb-intro/#section=configuration). 
 We have published our own orb called `silta/silta`, which enables you to use predefined jobs and commands.

--- a/docs/gcp_filestore_migration.md
+++ b/docs/gcp_filestore_migration.md
@@ -87,7 +87,7 @@ If you run out of free space on volume, contact cluster administrator for its ex
     ```
     Dockerfile example of a project
     ```dockerfile
-    FROM wunderio/silta-php-fpm:8.0-fpm-v0.1
+    FROM wunderio/silta-php-fpm:8.0-fpm-v1
     
     COPY --chown=www-data:www-data . /app
     

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -26,7 +26,7 @@ Versions available are listed here: https://github.com/wunderio/silta-images/tre
 
 Note: nginx:v0.1, wunderio/drupal Docker images do not have this module.
 
-Example: `FROM wunderio/silta-nginx:latest`
+Example: `FROM wunderio/silta-nginx:1.17-v1`
 
 # Issues with the deployed environments
 
@@ -297,7 +297,7 @@ Content of [silta/shell.Dockerfile](https://github.com/wunderio/drupal-project/b
 
 ```
 # Dockerfile for the Shell container.
-FROM wunderio/silta-php-shell:php7.4-v0.1
+FROM wunderio/silta-php-shell:php7.4-v1
 
 COPY --chown=www-data:www-data . /app
 ```
@@ -321,7 +321,7 @@ If You want to test docker images locally, You'd need to install docker or other
 
 Running a docker image:
 ```bash
-docker run -it --entrypoint sh wunderio/silta-php-shell:php7.4-v0.1
+docker run -it --entrypoint sh wunderio/silta-php-shell:php7.4-v1
 ```
 
 This will download shell image and run a shell inside it. Typing `exit` will quit and stop the container.

--- a/scripts/drupal7-migrate.sh
+++ b/scripts/drupal7-migrate.sh
@@ -15,7 +15,7 @@ cat > .circleci/config.yml << EOF
 version: 2.1
 
 orbs:
-  silta: silta/silta@0.1
+  silta: silta/silta@1
 
 workflows:
   version: 2


### PR DESCRIPTION
Silta component adjustments to use v1.0 tags. There are no functional changes in this PR, 
image tags are pointed to the same images as before, but with v1.0 tags. 
From now on, Silta will aim to follow semantic versioning practices.
More information here: https://github.com/wunderio/silta/releases/tag/2023-10-03

Please review adjusted image tags and make sure this PR only changes relevant 
configuration files, feel free to make changes for components that have been left 
out from this PR.

This pull request was created with https://github.com/wunderio/internal-mass-updater.