### PR TITLE
Dockerignore location change

### DIFF
--- a/scripts/drupal-migrate.sh
+++ b/scripts/drupal-migrate.sh
@@ -59,8 +59,9 @@ curl -s https://raw.githubusercontent.com/wunderio/drupal-project/master/silta/s
 curl -s https://raw.githubusercontent.com/wunderio/drupal-project/master/silta/silta-prod.yml > silta/silta-prod.yml
 
 echo "Adding dockerignore files"
-curl -s https://raw.githubusercontent.com/wunderio/drupal-project/master/.dockerignore > .dockerignore
-curl -s https://raw.githubusercontent.com/wunderio/drupal-project/master/web/.dockerignore > web/.dockerignore
+curl -s https://raw.githubusercontent.com/wunderio/drupal-project/master/silta/nginx.Dockerfile.dockerignore > silta/nginx.Dockerfile.dockerignore
+curl -s https://raw.githubusercontent.com/wunderio/drupal-project/master/silta/php.Dockerfile.dockerignore > silta/php.Dockerfile.dockerignore
+curl -s https://raw.githubusercontent.com/wunderio/drupal-project/master/silta/shell.Dockerfile.dockerignore > silta/shell.Dockerfile.dockerignore
 
 if [ ! -f phpcs.xml ]; then
   echo "Adding our standard phpcs.xml"

--- a/scripts/drupal7-migrate.sh
+++ b/scripts/drupal7-migrate.sh
@@ -72,8 +72,9 @@ curl -s https://raw.githubusercontent.com/wunderio/drupal-project/master/silta/s
 curl -s https://raw.githubusercontent.com/wunderio/drupal-project/master/silta/silta-prod.yml > silta/silta-prod.yml
 
 echo "Adding dockerignore files"
-curl -s https://raw.githubusercontent.com/wunderio/drupal-project/master/.dockerignore > .dockerignore
-curl -s https://raw.githubusercontent.com/wunderio/drupal-project/master/web/.dockerignore > web/.dockerignore
+curl -s https://raw.githubusercontent.com/wunderio/drupal-project/master/silta/nginx.Dockerfile.dockerignore > silta/nginx.Dockerfile.dockerignore
+curl -s https://raw.githubusercontent.com/wunderio/drupal-project/master/silta/php.Dockerfile.dockerignore > silta/php.Dockerfile.dockerignore
+curl -s https://raw.githubusercontent.com/wunderio/drupal-project/master/silta/shell.Dockerfile.dockerignore > silta/shell.Dockerfile.dockerignore
 
 echo "Updating settings.php"
 if ! grep -q "settings.silta.php" web/sites/default/settings.php


### PR DESCRIPTION
Dockerignore files moved to Dockerfile-specific dockerignore files. 
This depends on: https://github.com/wunderio/drupal-project/pull/427